### PR TITLE
Gadt translation can notice some parameters

### DIFF
--- a/src/signatureAxioms.ml
+++ b/src/signatureAxioms.ml
@@ -136,8 +136,9 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
       | [{ ci_params; ci_id_class_type; ci_expr; _ }] ->
         (ci_params |>
           List.map (fun ({ Typedtree.ctyp_type; _ }, _) -> ctyp_type) |>
-          TypeIsGadt.named_typ_params_expecting_variables
+          TypeIsGadt.inductive_variables
         ) >>= fun typ_params ->
+        let typ_params = TypeIsGadt.get_parameters typ_params in
         let* name = Name.of_ident false ci_id_class_type in
         begin match ci_expr with
         | {

--- a/src/signatureAxioms.ml
+++ b/src/signatureAxioms.ml
@@ -163,8 +163,6 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
                 NotSupported
                 "We do not handle this form of field of class type"
             )) >>= fun fields ->
-            (* let* typ_params = *)
-              (* TypeIsGadt.named_typ_params_with_unknowns typ_params in *)
             return [TypDefinition (TypeDefinition.Record (
               name,
               typ_params,

--- a/src/signatureAxioms.ml
+++ b/src/signatureAxioms.ml
@@ -162,8 +162,8 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
                 NotSupported
                 "We do not handle this form of field of class type"
             )) >>= fun fields ->
-            let* typ_params =
-              TypeIsGadt.named_typ_params_with_unknowns typ_params in
+            (* let* typ_params = *)
+              (* TypeIsGadt.named_typ_params_with_unknowns typ_params in *)
             return [TypDefinition (TypeDefinition.Record (
               name,
               typ_params,

--- a/src/type.ml
+++ b/src/type.ml
@@ -83,11 +83,11 @@ let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)
             ) in
         let gadt_shape = TypeIsGadt.gadt_shape typ_params constructors_return_typ_params in
 
-        return (List.map (fun shape ->
+        return (Some (gadt_shape |> List.map (fun shape ->
             match shape with
             | None -> Attribute.has_force_gadt typ_attributes
             | Some _ -> true
-          ) gadt_shape)
+          )))
       | Type_open -> return None
       end
     | exception Not_found -> return None

--- a/src/type.ml
+++ b/src/type.ml
@@ -28,18 +28,16 @@ let type_exprs_of_row_field (row_field : Types.row_field)
   | Rabsent -> []
 
 let filter_typ_params_in_valid_set
-  (typ_params : Name.t option list) (valid_set : Name.Set.t) : bool list =
-  typ_params |> List.map (function
-    | None -> false
-    | Some typ_param -> Name.Set.mem typ_param valid_set
-  )
+  (typ_params : Name.t list) (valid_set : Name.Set.t) : bool list =
+  typ_params |> List.map (function ty -> Name.Set.mem ty valid_set)
+
 
 let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)
   : Types.type_expr list Monad.t =
   get_env >>= fun env ->
   begin match Env.find_type path env with
   | typ_declaration ->
-    TypeIsGadt.typ_params_ghost_marked
+    TypeIsGadt.inductive_variables
       typ_declaration.type_params >>= fun typ_params ->
     Attribute.of_attributes typ_declaration.type_attributes >>= fun typ_attributes ->
     let is_phantom = Attribute.has_phantom typ_attributes in
@@ -51,21 +49,22 @@ let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)
         begin match typ_declaration.type_manifest with
         | None ->
           return (Some (typ_params |> List.map (function
-            | None ->
+            | TypeIsGadt.InductiveVariable.Parameter _ -> true
+            | _ ->
               if Path.name path = "array" then
                 true
               else
                 false
-            | Some _ -> true
           )))
         (* Specific case for inductives defined with polymorphic variants. *)
         | Some { desc = Tvariant _; _ } ->
           return (Some (typ_params |> List.map (function
-            | None -> false
-            | Some _ -> true
+            | TypeIsGadt.InductiveVariable.Parameter _ -> true
+            | _ -> false
           )))
         | Some typ ->
           non_phantom_vars_of_typ typ >>= fun non_phantom_typ_vars ->
+          let typ_params = TypeIsGadt.get_parameters typ_params in
           return (Some (
             filter_typ_params_in_valid_set typ_params non_phantom_typ_vars
           ))
@@ -73,23 +72,22 @@ let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)
       | Type_record (labels, _) ->
         let typs = List.map (fun label -> label.ld_type) labels in
         non_phantom_vars_of_typs typs >>= fun non_phantom_typ_vars ->
+        let typ_params = TypeIsGadt.get_parameters typ_params in
         return (Some (
           filter_typ_params_in_valid_set typ_params non_phantom_typ_vars
         ))
       | Type_variant constructors ->
-        let typ_params = typ_params |> List.filter_map (function x -> x) in
-        let* is_not_gadt =
-          let* constructors_return_typ_params =
-            constructors |> Monad.List.map (fun constructor ->
+        let* constructors_return_typ_params =
+          constructors |> Monad.List.map (fun constructor ->
               TypeIsGadt.get_return_typ_params typ_params constructor.cd_res
             ) in
-          return (
-            not (Attribute.has_force_gadt typ_attributes) &&
-            match TypeIsGadt.check_if_not_gadt typ_params constructors_return_typ_params with
-            | None -> false
+        let gadt_shape = TypeIsGadt.gadt_shape typ_params constructors_return_typ_params in
+
+        return (List.map (fun shape ->
+            match shape with
+            | None -> Attribute.has_force_gadt typ_attributes
             | Some _ -> true
-          ) in
-        return (Some (typ_params |> List.map (fun _ -> is_not_gadt)))
+          ) gadt_shape)
       | Type_open -> return None
       end
     | exception Not_found -> return None
@@ -143,7 +141,7 @@ and non_phantom_vars_of_typ (typ : Types.type_expr) : Name.Set.t Monad.t =
       TypeIsGadt.typ_params_ghost_marked typ_args in
     let typ_args =
       typ_args |>
-      Util.List.filter_map (fun x -> x) |>
+      TypeIsGadt.get_parameters |>
       Name.Set.of_list in
     non_phantom_vars_of_typ typ >>= fun non_phantom_vars ->
     return (Name.Set.diff non_phantom_vars typ_args)
@@ -253,7 +251,7 @@ let rec of_typ_expr
   | Tpoly (typ, typ_args) ->
     let* typ_args =
       TypeIsGadt.typ_params_ghost_marked typ_args in
-    let typ_args = typ_args |> Util.List.filter_map (fun x -> x) in
+    let typ_args = typ_args |> TypeIsGadt.get_parameters in
     non_phantom_vars_of_typ typ >>= fun non_phantom_vars ->
     let typ_args = typ_args |> List.filter (fun typ_arg ->
       Name.Set.mem typ_arg non_phantom_vars

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -108,7 +108,7 @@ module Constructors = struct
       constructor_name : Name.t;
       param_typs : Type.t list; (** The parameters of the constructor. *)
       return_typ_params : Name.t option list option;
-        (** The return type, in case of GADT contructor, with some inference to
+        (** The return type, in case of GADT constructor, with some inference to
             rule-out GADTs with only existential variables. *)
     }
 

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -152,7 +152,6 @@ module Constructors = struct
             []
             (List.map Type.typ_args_of_typ record_params) in
         return (
-
           [
             Type.Apply (
               MixedPath.PathName {
@@ -584,6 +583,22 @@ let filter_in_free_vars
         None
   )
 
+let gadt_prename
+    (name : Name.t)
+    (defined_typ_params : Name.t option list)
+    (constructors_return_typ_params : Constructors.Single.t list)
+    : Name.t =
+    match name with
+      | FunctionParameter -> name
+      | Make s ->
+        let constructors_return_typ_params =
+          constructors_return_typ_params |> List.map (fun constructor_return_typ_params ->
+              constructor_return_typ_params.Constructors.Single.return_typ_params
+            ) in
+        match TypeIsGadt.check_if_not_gadt defined_typ_params constructors_return_typ_params with
+        | Some _ -> name
+        | None -> Make ("pre_" ^ s)
+
 let of_ocaml (typs : type_declaration list) : t Monad.t =
   match typs with
   | [ { typ_id; typ_type = { type_manifest = Some typ; type_params; _ }; _ } ] ->
@@ -709,6 +724,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (single_constructors, new_constructor_records) = List.split cases in
         let new_constructor_records =
           new_constructor_records |> Util.List.filter_map (fun x -> x) in
+        let name = gadt_prename name typ_args single_constructors in
         let constructor_records =
           match new_constructor_records with
           | [] -> constructor_records

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -237,7 +237,6 @@ module Constructors = struct
           let merged_typ_params =
             TypeIsGadt.get_parameters merged_typ_params in
           let res_typ_params =
-            (* List.map (fun name -> Type.Variable name) res_typ_params in *)
             List.map (fun name -> Type.Variable name) merged_typ_params in
           return {
             constructor_name;
@@ -336,11 +335,7 @@ module Inductive = struct
       else
         parens (
           nest (
-            separate space (left_typ_args |> List.map ( Name.to_coq
-                (* function *)
-                  (* None -> !^ "_" *)
-                (* | Some name -> Name.to_coq name *)
-            )) ^^
+            separate space (left_typ_args |> List.map Name.to_coq) ^^
             !^ ":" ^^ Pp.set
           )
         )

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -583,22 +583,6 @@ let filter_in_free_vars
         None
   )
 
-let gadt_prename
-    (name : Name.t)
-    (defined_typ_params : Name.t option list)
-    (constructors_return_typ_params : Constructors.Single.t list)
-    : Name.t =
-    match name with
-      | FunctionParameter -> name
-      | Make s ->
-        let constructors_return_typ_params =
-          constructors_return_typ_params |> List.map (fun constructor_return_typ_params ->
-              constructor_return_typ_params.Constructors.Single.return_typ_params
-            ) in
-        match TypeIsGadt.check_if_not_gadt defined_typ_params constructors_return_typ_params with
-        | Some _ -> name
-        | None -> Make ("pre_" ^ s)
-
 let of_ocaml (typs : type_declaration list) : t Monad.t =
   match typs with
   | [ { typ_id; typ_type = { type_manifest = Some typ; type_params; _ }; _ } ] ->
@@ -724,7 +708,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (single_constructors, new_constructor_records) = List.split cases in
         let new_constructor_records =
           new_constructor_records |> Util.List.filter_map (fun x -> x) in
-        let name = gadt_prename name typ_args single_constructors in
         let constructor_records =
           match new_constructor_records with
           | [] -> constructor_records

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -86,15 +86,24 @@ let print_typParams (tys : TypParams.t) : unit =
            |> String.concat ", " in
   print_string ("Ty Params : " ^ ts ^ "\n")
 
+let rec adt_parameters
+  (defined_typ_params : TypParams.t)
+  (constructors_return_typ_params : TypParams.t list)
+  : TypParams.t =
+  match constructors_return_typ_params with
+  | [] -> defined_typ_params
+  | return_typ_params :: constructors_return_typ_params ->
+    let typ_params = merge_typ_params defined_typ_params return_typ_params in
+    adt_parameters typ_params constructors_return_typ_params
+
 (** Check if the type is not a GADT. If this is not a GADT, also return a
   prefered list of parameter names for the type variables. It merges the
   names found in the definition of the type name and in the constructors. *)
-let rec check_if_not_gadt
-  (defined_typ_params : TypParams.t)
-  (constructors_return_typ_params : TypParams.t list)
+let check_if_not_gadt
+    (defined_typ_params : TypParams.t)
+    (constructors_return_typ_params : TypParams.t list)
   : TypParams.t option =
-  match constructors_return_typ_params with
-  | [] -> Some defined_typ_params
-  | return_typ_params :: constructors_return_typ_params ->
-    let typ_params = merge_typ_params defined_typ_params return_typ_params in
-    check_if_not_gadt typ_params constructors_return_typ_params
+  let typ_params = adt_parameters defined_typ_params constructors_return_typ_params in
+      if typ_params <> defined_typ_params
+      then Some typ_params
+      else None

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -8,7 +8,7 @@ module TypeVariable = struct
 end
 
 module TypParams = struct
-  type t = Name.t option list
+  type t = Name.t list
 end
 
 let rec named_typ_param (typ : Types.type_expr) : TypeVariable.t Monad.t =
@@ -24,22 +24,21 @@ let rec named_typ_param (typ : Types.type_expr) : TypeVariable.t Monad.t =
   | _ -> return TypeVariable.Error
 
 let filter_error_params (typs : Types.type_expr list)
-  : TypParams.t option Monad.t =
+  : TypParams.t Monad.t =
   Monad.List.map named_typ_param typs >>= fun typs ->
-  let x : TypParams.t = typs |>
-          List.map (function
-              | TypeVariable.Error ->
-                None
-              | Known name ->
-                Some name
-              | Unknown ->
-                None) in
-  return (Some x)
+  typs |> List.filter_map (function
+      | TypeVariable.Error ->
+        None
+      | Known name ->
+        Some name
+      | Unknown ->
+        None)
+  |> return
 
 let named_typ_params_expecting_variables (typs : Types.type_expr list)
   : TypParams.t Monad.t =
   Monad.List.map named_typ_param typs >>= fun typs ->
-  typs |> Monad.List.map (function
+  typs |> Monad.List.filter_map (function
     | TypeVariable.Error ->
       raise
         None
@@ -49,8 +48,9 @@ let named_typ_params_expecting_variables (typs : Types.type_expr list)
     | Unknown -> return None
   )
 
-let named_typ_params_expecting_variables_or_ignored
-  (typs : Types.type_expr list) : TypParams.t Monad.t =
+
+let typ_params_ghost_marked
+  (typs : Types.type_expr list) : Name.t option list Monad.t =
   Monad.List.map named_typ_param typs >>= fun typs ->
   return (typs |> List.map (function
     | TypeVariable.Error -> None
@@ -58,18 +58,29 @@ let named_typ_params_expecting_variables_or_ignored
     | Unknown -> None
   ))
 
-let named_typ_params_with_unknowns (typ_params : TypParams.t)
-  : Name.t list Monad.t =
-  typ_params |> Monad.List.map (function
-    | Some typ_param -> return typ_param
-    | None -> Name.of_string false "_"
-  )
+(* let named_typ_params_expecting_variables_or_ignored
+ *   (typs : Types.type_expr list) : TypParams.t Monad.t =
+ *   Monad.List.map named_typ_param typs >>= fun typs ->
+ *   return (typs |> List.filter_map (function
+ *     | TypeVariable.Error -> None
+ *     | Known name -> Some name
+ *     | Unknown -> None
+ *   )) *)
 
-let named_typ_params_without_unknowns (typ_params : TypParams.t) : Name.t list =
-  typ_params |> Util.List.filter_map (function
-    | Some typ_param -> Some typ_param
-    | None -> None
-  )
+(* let named_typ_params_with_unknowns (typ_params : TypParams.t) *)
+  (* : TypeParams.t Monad.t = *)
+  (* typ_params |> Monad.List.map (function *)
+    (* | Some typ_param -> return typ_param *)
+    (* | None -> Name.of_string false "_" *)
+  (* ) |> return *)
+
+(* let named_typ_params_without_unknowns (typ_params : TypParams.t) : Name.t list = *)
+  (* typ_params |> Util.List.filter_map (function *)
+    (* | Some typ_param -> Some typ_param *)
+    (* | None -> None *)
+  (* ) *)
+
+
 
 let rec merge_typ_params (params1 : TypParams.t) (params2 : TypParams.t)
   : TypParams.t option =
@@ -78,54 +89,38 @@ let rec merge_typ_params (params1 : TypParams.t) (params2 : TypParams.t)
   | (_ :: _, []) | ([], _ :: _) -> None
   | (param1 :: params1, param2 :: params2) ->
     Util.Option.bind (merge_typ_params params1 params2) (fun params ->
-    match (param1, param2) with
-    | (Some param1, Some param2) ->
       if Name.equal param1 param2 then
-        Some (Some param1 :: params)
+        Some (param1 :: params)
       else
-        Some (params)
-    | (Some _, None) | (None, Some _) -> Some (None :: params)
-    | (None, None) -> Some (None :: params))
+        None)
 
 (** Get the parameters of the return type of a constructor if the parameters are
     only variables. Defaults to the parameters of the defined type itself, in
     case of a non-GADT type. *)
 let get_return_typ_params
   (defined_typ_params : TypParams.t) (return_typ : Types.type_expr option)
-  : TypParams.t option Monad.t =
+  : TypParams.t Monad.t =
   match return_typ with
   | Some { Types.desc = Tconstr (_, typs, _); _ } ->
     filter_error_params typs
-  | _ -> return (Some (defined_typ_params))
+  | _ -> return (defined_typ_params)
+
+let print_typParams (tys : TypParams.t) : unit =
+  let ts = tys |> List.map (function ty -> Name.to_string ty )
+           |> String.concat ", " in
+  print_string ("Ty Params : " ^ ts ^ "\n")
 
 (** Check if the type is not a GADT. If this is not a GADT, also return a
   prefered list of parameter names for the type variables. It merges the
   names found in the definition of the type name and in the constructors. *)
 let rec check_if_not_gadt
   (defined_typ_params : TypParams.t)
-  (constructors_return_typ_params : TypParams.t option list)
+  (constructors_return_typ_params : TypParams.t list)
   : TypParams.t option =
   match constructors_return_typ_params with
   | [] -> Some defined_typ_params
   | return_typ_params :: constructors_return_typ_params ->
-    begin match return_typ_params with
-    | None -> None
-    | Some return_typ_params ->
-      let are_variables_num_different =
-        let non_null_variables =
-          Util.List.filter_map (fun x -> x) return_typ_params in
-        List.length non_null_variables <>
-          Name.Set.cardinal (Name.Set.of_list non_null_variables) in
-      if are_variables_num_different then
-        None
-      else
-        let ret = Util.Option.bind
-          (merge_typ_params defined_typ_params return_typ_params)
-          (fun defined_typ_params ->
-            check_if_not_gadt defined_typ_params constructors_return_typ_params 
-          ) in
-        begin match ret with
-          | None -> None
-          | Some tys -> Some (tys |> List.filter (function | None -> false | Some _ -> true))
-        end
-    end
+    Util.Option.bind
+      (merge_typ_params defined_typ_params return_typ_params)
+      (fun defined_typ_params ->
+         check_if_not_gadt defined_typ_params constructors_return_typ_params)

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -12,6 +12,10 @@ module IndParams = struct
   type t = InductiveVariable.t list
 end
 
+let get_name : InductiveVariable.t -> Name.t option = function
+  | InductiveVariable.Parameter name | Index name -> Some name
+  | _ -> None
+
 let get_parameters (typs : IndParams.t) : Name.t list =
   typs |> List.filter_map (function
       | InductiveVariable.Parameter name -> Some name

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -1,109 +1,132 @@
 open Monad.Notations
 
-module TypeVariable = struct
+module InductiveVariable = struct
   type t =
     | Error
-    | Known of Name.t
+    | Parameter of Name.t
+    | Index of Name.t
     | Unknown
 end
 
-module TypParams = struct
-  type t = Name.t list
+module IndParams = struct
+  type t = InductiveVariable.t list
 end
 
-let rec named_typ_param (typ : Types.type_expr) : TypeVariable.t Monad.t =
+let get_parameters (typs : IndParams.t) : Name.t list =
+  typs |> List.filter_map (function
+      | InductiveVariable.Parameter name -> Some name
+      | _ -> None)
+
+let rec inductive_variable (typ : Types.type_expr) : InductiveVariable.t Monad.t =
   match typ.Types.desc with
   | Tvar x | Tunivar x ->
     begin match x with
-    | None | Some "_" -> return TypeVariable.Unknown
+    | None | Some "_" -> return InductiveVariable.Unknown
     | Some x ->
       Name.of_string false x >>= fun x ->
-      return (TypeVariable.Known x)
+      return (InductiveVariable.Parameter x)
     end
-  | Tlink typ | Tsubst typ -> named_typ_param typ
-  | _ -> return TypeVariable.Error
+  | Tlink typ | Tsubst typ -> inductive_variable typ
+  | Tconstr (typ, _, _) ->
+    Path.last typ |> Name.of_string false >>= fun typ ->  return (InductiveVariable.Index typ)
+  | _ -> return InductiveVariable.Error
 
-let filter_error_params (typs : Types.type_expr list)
-  : TypParams.t Monad.t =
-  Monad.List.map named_typ_param typs >>= fun typs ->
-  typs |> List.filter_map (function
-      | TypeVariable.Error ->
-        None
-      | Known name ->
-        Some name
-      | Unknown ->
-        None)
+let inductive_variables (typs : Types.type_expr list) : InductiveVariable.t list Monad.t =
+  Monad.List.map inductive_variable typs
+
+let filter_params (typs : Types.type_expr list)
+  : IndParams.t Monad.t =
+  Monad.List.map inductive_variable typs >>= fun typs ->
+  typs |> List.filter (function
+      | InductiveVariable.Parameter _ -> true
+      | _ -> false)
   |> return
 
-let named_typ_params_expecting_variables (typs : Types.type_expr list)
-  : TypParams.t Monad.t =
-  Monad.List.map named_typ_param typs >>= fun typs ->
-  typs |> Monad.List.filter_map (function
-    | TypeVariable.Error ->
-      raise
-        None
-        Unexpected
-        "Expected a list of named or unspecified '_' type variables"
-    | Known name -> return (Some name)
-    | Unknown -> return None
-  )
+  let typ_params_ghost_marked
+  (typs : Types.type_expr list) : IndParams.t Monad.t =
+  typs |> filter_params
 
+let equal (param1 : InductiveVariable.t) (param2 : InductiveVariable.t) =
+  match param1, param2 with
+  | Error, Error | Unknown, Unknown -> true
+  | Parameter name1, Parameter name2 | Index name1, Index name2 -> Name.equal name1 name2
+  | _, _ -> false
 
-let typ_params_ghost_marked
-  (typs : Types.type_expr list) : Name.t option list Monad.t =
-  Monad.List.map named_typ_param typs >>= fun typs ->
-  return (typs |> List.map (function
-    | TypeVariable.Error -> None
-    | Known name -> Some name
-    | Unknown -> None
-  ))
-
-let rec merge_typ_params (params1 : TypParams.t) (params2 : TypParams.t)
-  : TypParams.t =
+let rec merge_typ_params
+    (params1 : InductiveVariable.t option list)
+    (params2 : InductiveVariable.t option list)
+  : InductiveVariable.t option list =
   match (params1, params2) with
   | ([], []) -> []
-  | (_ :: _ as xs, []) | ([], (_ :: _ as xs)) -> xs
+  | (_ :: _, []) | ([], _ :: _) -> []
   | (param1 :: params1, param2 :: params2) ->
     let params = merge_typ_params params1 params2 in
-    if Name.equal param1 param2 then
-      param1 :: params
-    else
-      params
+    begin match (param1, param2) with
+      | (Some param1, Some param2) ->
+        if equal param1 param2 then
+          Some param1 :: params
+        else
+          None :: params
+      | (Some _, None) | (None, Some _) -> None :: params
+      | (None, None) -> None :: params
+    end
 
 (** Get the parameters of the return type of a constructor if the parameters are
     only variables. Defaults to the parameters of the defined type itself, in
     case of a non-GADT type. *)
 let get_return_typ_params
-  (defined_typ_params : TypParams.t) (return_typ : Types.type_expr option)
-  : TypParams.t Monad.t =
+  (defined_typ_params : IndParams.t) (return_typ : Types.type_expr option)
+  : IndParams.t Monad.t =
   match return_typ with
   | Some { Types.desc = Tconstr (_, typs, _); _ } ->
-    filter_error_params typs
+    Monad.List.map inductive_variable typs
   | _ -> return (defined_typ_params)
 
-let print_typParams (tys : TypParams.t) : unit =
-  let ts = tys |> List.map (function ty -> Name.to_string ty )
-           |> String.concat ", " in
-  print_string ("Ty Params : " ^ ts ^ "\n")
-
 let rec adt_parameters
-  (defined_typ_params : TypParams.t)
-  (constructors_return_typ_params : TypParams.t list)
-  : TypParams.t =
+    (defined_typ_params : InductiveVariable.t option list)
+    (constructors_return_typ_params : InductiveVariable.t option list list)
+  : IndParams.t =
+  match constructors_return_typ_params with
+  | [] -> List.filter_map (fun x -> x) defined_typ_params
+  | return_typ_params :: constructors_return_typ_params ->
+    let typ_params = merge_typ_params defined_typ_params return_typ_params in
+    adt_parameters typ_params constructors_return_typ_params
+
+
+let rec gadt_shape'
+    (defined_typ_params : InductiveVariable.t option list)
+    (constructors_return_typ_params : InductiveVariable.t option list list)
+  : InductiveVariable.t option list =
   match constructors_return_typ_params with
   | [] -> defined_typ_params
   | return_typ_params :: constructors_return_typ_params ->
     let typ_params = merge_typ_params defined_typ_params return_typ_params in
-    adt_parameters typ_params constructors_return_typ_params
+    gadt_shape' typ_params constructors_return_typ_params
+
+let gadt_shape
+    (defined_typ_params : InductiveVariable.t list)
+    (constructors_return_typ_params : InductiveVariable.t list list)
+  : InductiveVariable.t option list =
+  let defined_typ_params = List.map (function x -> Some x) defined_typ_params in
+  let constructors_return_typ_params =
+    List.map (function xs ->
+        List.map (function x -> Some x) xs)
+      constructors_return_typ_params in
+  gadt_shape' defined_typ_params constructors_return_typ_params
 
 (** Check if the type is not a GADT. If this is not a GADT, also return a
   prefered list of parameter names for the type variables. It merges the
   names found in the definition of the type name and in the constructors. *)
 let check_if_not_gadt
-    (defined_typ_params : TypParams.t)
-    (constructors_return_typ_params : TypParams.t list)
-  : TypParams.t option =
-  let typ_params = adt_parameters defined_typ_params constructors_return_typ_params in
+    (defined_typ_params : IndParams.t)
+    (constructors_return_typ_params : IndParams.t list)
+  : IndParams.t option =
+  let defined_typ_params' = List.map (function x -> Some x) defined_typ_params in
+  let constructors_return_typ_params =
+    List.map (function xs ->
+        List.map (function x -> Some x) xs)
+      constructors_return_typ_params in
+  let typ_params = adt_parameters defined_typ_params' constructors_return_typ_params in
       if typ_params <> defined_typ_params
       then Some typ_params
       else None


### PR DESCRIPTION
Closes #129 

With this pull request I also start a big revamp of `TypeIsGadt.ml` to provide a much better interface. The key idea is to stop using `Name.t list option` in favor of `InductiveVariable.t list`, this way the datatypes constructors in `TypeDefinition` will have direct access to all the parameters and indexes, even if we are going to erase them later. Notice that in the future we will still need all this information stored somewhere in order to be able to fully translate Gadts.

It seems to me that `TypeIsGadt` should be a module to manage all the treatment of `TypeVariables` of inductives, with `Name.t list option` the clients of this module will still have to figure out how to treat this information.

`gadt_shape` is the same as `check_if_not_gadt`, but still using `InductiveVariable.t option list` because I didn't update how `Type.non_phantom_typs` works, and it still relies on `option list`. In the future I will simplify `Typ.non_phantom_typs` to take full advantage of the new interface that I am building in `TypeIsGadt.ml`.
