### PR TITLE
Gadt translation notices some parameters

### DIFF
--- a/src/signatureAxioms.ml
+++ b/src/signatureAxioms.ml
@@ -136,8 +136,9 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
       | [{ ci_params; ci_id_class_type; ci_expr; _ }] ->
         (ci_params |>
           List.map (fun ({ Typedtree.ctyp_type; _ }, _) -> ctyp_type) |>
-          TypeIsGadt.named_typ_params_expecting_variables
+          TypeIsGadt.inductive_variables
         ) >>= fun typ_params ->
+        let typ_params = TypeIsGadt.get_parameters typ_params in
         let* name = Name.of_ident false ci_id_class_type in
         begin match ci_expr with
         | {
@@ -162,8 +163,6 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
                 NotSupported
                 "We do not handle this form of field of class type"
             )) >>= fun fields ->
-            let* typ_params =
-              TypeIsGadt.named_typ_params_with_unknowns typ_params in
             return [TypDefinition (TypeDefinition.Record (
               name,
               typ_params,

--- a/src/type.ml
+++ b/src/type.ml
@@ -29,7 +29,7 @@ let type_exprs_of_row_field (row_field : Types.row_field)
 
 let filter_typ_params_in_valid_set
   (typ_params : Name.t list) (valid_set : Name.Set.t) : bool list =
-  typ_params |> List.map (function ty -> Name.Set.mem ty valid_set)
+  typ_params |> List.map (fun ty -> Name.Set.mem ty valid_set)
 
 
 let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -107,14 +107,14 @@ module Constructors = struct
     type t = {
       constructor_name : Name.t;
       param_typs : Type.t list; (** The parameters of the constructor. *)
-      return_typ_params : Name.t option list option;
+      return_typ_params : TypeIsGadt.IndParams.t;
         (** The return type, in case of GADT constructor, with some inference to
             rule-out GADTs with only existential variables. *)
     }
 
     let of_ocaml_case
       (typ_name : Name.t)
-      (defined_typ_params : Name.t option list)
+      (defined_typ_params : TypeIsGadt.IndParams.t)
       (case : Types.constructor_declaration)
       : (t * (RecordSkeleton.t * Name.t list * Type.t) option) Monad.t =
       let { Types.cd_args; cd_id; cd_loc; cd_res; _ } = case in
@@ -144,10 +144,10 @@ module Constructors = struct
         let typ_args =
           List.fold_left
             (fun typ_args new_typ_args ->
-              typ_args @
-              Name.Set.elements (
-                Name.Set.diff new_typ_args (Name.Set.of_list typ_args)
-              )
+               (typ_args @
+               Name.Set.elements (
+                 Name.Set.diff new_typ_args (Name.Set.of_list typ_args)
+               ))
             )
             []
             (List.map Type.typ_args_of_typ record_params) in
@@ -192,7 +192,7 @@ module Constructors = struct
       ))
 
     let of_ocaml_row
-      (defined_typ_params : Name.t option list)
+      (defined_typ_params : TypeIsGadt.IndParams.t)
       (row : Asttypes.label * Types.row_field)
       : t Monad.t =
       let (label, field) = row in
@@ -202,26 +202,27 @@ module Constructors = struct
       return {
         constructor_name;
         param_typs;
-        return_typ_params = Some defined_typ_params;
+        return_typ_params = defined_typ_params;
       }
   end
 
   let of_ocaml
-    (defined_typ_params : Name.t option list)
+    (defined_typ_params : TypeIsGadt.IndParams.t)
     (force_gadt : bool)
     (single_constructors : Single.t list)
-    : (t * Name.t option list option) Monad.t =
+    : (t * TypeIsGadt.IndParams.t option) Monad.t =
     let merged_typ_params =
       if force_gadt then
         None
       else
         let constructors_return_typ_params =
           single_constructors |> List.map (fun single_constructor ->
-            single_constructor.Single.return_typ_params
-          ) in
+              single_constructor.Single.return_typ_params
+            ) in
         TypeIsGadt.check_if_not_gadt
           defined_typ_params
           constructors_return_typ_params in
+
     let* constructors = single_constructors |> Monad.List.map (
       fun { Single.constructor_name; param_typs; _ } ->
         match merged_typ_params with
@@ -233,10 +234,10 @@ module Constructors = struct
             typ_vars = Name.Set.elements (Type.typ_args_of_typs param_typs)
           }
         | Some merged_typ_params ->
-          let* res_typ_params =
-            TypeIsGadt.named_typ_params_with_unknowns merged_typ_params in
+          let merged_typ_params =
+            TypeIsGadt.get_parameters merged_typ_params in
           let res_typ_params =
-            List.map (fun name -> Type.Variable name) res_typ_params in
+            List.map (fun name -> Type.Variable name) merged_typ_params in
           return {
             constructor_name;
             param_typs;
@@ -246,7 +247,6 @@ module Constructors = struct
                 Name.Set.diff
                   (Type.typ_args_of_typs param_typs)
                   (merged_typ_params |>
-                    Util.List.filter_map (fun x -> x) |>
                     Name.Set.of_list
                   )
               )
@@ -263,7 +263,7 @@ module Inductive = struct
       : (Name.t * (RecordSkeleton.t * Name.t list * Type.t) list) list;
     notations : notation list;
     records : RecordSkeleton.t list;
-    typs : (Name.t * Name.t option list * Constructors.t) list;
+    typs : (Name.t * Name.t list * Constructors.t) list;
   }
 
   let get_notation_module_name (inductive : t) : SmartPrint.t =
@@ -324,7 +324,7 @@ module Inductive = struct
     (subst : Type.Subst.t)
     (is_first : bool)
     (name : Name.t)
-    (left_typ_args : Name.t option list)
+    (left_typ_args : Name.t list)
     (constructors : Constructors.t)
     : SmartPrint.t =
     let keyword = if is_first then !^ "Inductive" else !^ "with" in
@@ -335,10 +335,7 @@ module Inductive = struct
       else
         parens (
           nest (
-            separate space (left_typ_args |> List.map (function
-              None -> !^ "_"
-              | Some name -> Name.to_coq name
-            )) ^^
+            separate space (left_typ_args |> List.map Name.to_coq) ^^
             !^ ":" ^^ Pp.set
           )
         )
@@ -474,7 +471,7 @@ module Inductive = struct
     )
 
   let to_coq_typs_implicits
-    (left_typ_args : Name.t option list)
+    (left_typ_args : Name.t list)
     (constructors : Constructors.t)
     : SmartPrint.t list =
     match left_typ_args with
@@ -573,10 +570,8 @@ type t =
   | Abstract of Name.t * Name.t list
 
 let filter_in_free_vars
-  (typ_args : TypeIsGadt.TypParams.t) (free_vars : Name.Set.t) : Name.t list =
-  typ_args |> Util.List.filter_map (function
-    | None -> None
-    | Some typ_arg ->
+  (typ_args : Name.t list) (free_vars : Name.Set.t) : Name.t list =
+  typ_args |> Util.List.filter_map (function typ_arg ->
       if Name.Set.mem typ_arg free_vars then
         Some typ_arg
       else
@@ -587,13 +582,14 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
   match typs with
   | [ { typ_id; typ_type = { type_manifest = Some typ; type_params; _ }; _ } ] ->
     let* name = Name.of_ident false typ_id in
-    TypeIsGadt.named_typ_params_expecting_variables type_params >>= fun typ_args ->
+    TypeIsGadt.inductive_variables type_params >>= fun ind_vars ->
+    let typ_args = TypeIsGadt.get_parameters ind_vars in
     begin match typ.Types.desc with
     | Tvariant { row_fields; _ } ->
       Monad.List.map
-        (Constructors.Single.of_ocaml_row typ_args)
+        (Constructors.Single.of_ocaml_row ind_vars)
         row_fields >>= fun single_constructors ->
-      Constructors.of_ocaml typ_args false single_constructors >>= fun (constructors, _) ->
+      Constructors.of_ocaml ind_vars false single_constructors >>= fun (constructors, _) ->
       raise
         (Inductive {
           constructor_records = [];
@@ -612,22 +608,23 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
   | [ { typ_id; typ_type = { type_kind = Type_abstract; type_manifest = None; type_params; _ }; typ_attributes; _ } ] ->
     Attribute.of_attributes typ_attributes >>= fun typ_attributes ->
     let* name = Name.of_ident false typ_id in
-    TypeIsGadt.named_typ_params_expecting_variables type_params >>= fun typ_args ->
+    TypeIsGadt.inductive_variables type_params >>= fun typ_args ->
     let typ_args_with_unknowns =
       if not (Attribute.has_phantom typ_attributes) then
-        TypeIsGadt.named_typ_params_without_unknowns typ_args
+        TypeIsGadt.get_parameters typ_args
       else
         [] in
     return (Abstract (name, typ_args_with_unknowns))
   | [ { typ_id; typ_type = { type_kind = Type_record (fields, _); type_params; _ }; _ } ] ->
     let* name = Name.of_ident false typ_id in
-    TypeIsGadt.named_typ_params_expecting_variables type_params >>= fun typ_args ->
+    TypeIsGadt.inductive_variables type_params >>= fun typ_args ->
     (fields |> Monad.List.map (fun { Types.ld_id = x; ld_type = typ; _ } ->
       let* x = Name.of_ident false x in
       Type.of_type_expr_without_free_vars typ >>= fun typ ->
       return (x, typ)
     )) >>= fun fields ->
     let free_vars = Type.typ_args_of_typs (List.map snd fields) in
+    let typ_args = TypeIsGadt.get_parameters typ_args in
     let typ_args = filter_in_free_vars typ_args free_vars in
     return (Record (name, typ_args, fields, true))
   | [ { typ_id; typ_type = { type_kind = Type_open; _ }; _ } ] ->
@@ -641,7 +638,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
     (typs |> Monad.List.fold_left (fun (constructor_records, notations, records, typs) typ ->
       set_loc (Loc.of_location typ.typ_loc) (
       let* name = Name.of_ident false typ.typ_id in
-      TypeIsGadt.named_typ_params_expecting_variables typ.typ_type.type_params >>= fun typ_args ->
+      TypeIsGadt.inductive_variables typ.typ_type.type_params >>= fun typ_args ->
       match typ with
       | { typ_type = { type_manifest = Some typ; _ }; _ } ->
         begin match typ.Types.desc with
@@ -660,7 +657,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         | _ ->
           Type.of_type_expr_without_free_vars typ >>= fun typ ->
           let free_vars = Type.typ_args_of_typ typ in
-          let typ_args = filter_in_free_vars typ_args free_vars in
+          let typ_args = filter_in_free_vars (TypeIsGadt.get_parameters typ_args) free_vars in
           return (
             constructor_records,
             (
@@ -684,6 +681,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
           return (x, typ)
         )) >>= fun fields ->
         let free_vars = Type.typ_args_of_typs (List.map snd fields) in
+        let typ_args = TypeIsGadt.get_parameters typ_args in
         let typ_args = filter_in_free_vars typ_args free_vars in
         return (
           constructor_records,
@@ -734,6 +732,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
           "We do not handle extensible types"
       )
     ) ([], [], [], [])) >>= fun (constructor_records, notations, records, typs) ->
+    let typs = typs |> List.map (function (x, y, z) -> (x, TypeIsGadt.get_parameters y, z)) in
     return (
       Inductive {
         constructor_records = List.rev constructor_records;

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -215,21 +215,21 @@ module Constructors = struct
       single_constructors |> List.map (fun single_constructor ->
           single_constructor.Single.return_typ_params
         ) in
-
-    let typ_params =
-        match (TypeIsGadt.check_if_not_gadt
+    let merged_typ_params = TypeIsGadt.check_if_not_gadt
                 defined_typ_params
-                constructors_return_typ_params) with
+                constructors_return_typ_params in
+    let typ_params =
+        match merged_typ_params with
       | None -> defined_typ_params
-      | Some typs -> typs in
+      | Some merged_typ_params -> merged_typ_params in
 
     let* constructors = single_constructors |> Monad.List.map (
       fun { Single.constructor_name; param_typs; _ } ->
           let res_typ_params =
             typ_params |> TypeIsGadt.get_parameters |> List.map (fun name -> Type.Variable name) in
           let typ_param_names = (typ_params |> List.map TypeIsGadt.get_name |>
-                                 List.filter_map (function x -> x) |> Name.Set.of_list)
-          in return {
+                                 List.filter_map (function x -> x) |> Name.Set.of_list) in
+          return {
             constructor_name;
             param_typs;
             res_typ_params;

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -108,7 +108,7 @@ module Constructors = struct
       constructor_name : Name.t;
       param_typs : Type.t list; (** The parameters of the constructor. *)
       return_typ_params : Name.t option list option;
-        (** The return type, in case of GADT contructor, with some inference to
+        (** The return type, in case of GADT constructor, with some inference to
             rule-out GADTs with only existential variables. *)
     }
 
@@ -152,7 +152,6 @@ module Constructors = struct
             []
             (List.map Type.typ_args_of_typ record_params) in
         return (
-
           [
             Type.Apply (
               MixedPath.PathName {
@@ -584,6 +583,22 @@ let filter_in_free_vars
         None
   )
 
+let gadt_prename
+    (name : Name.t)
+    (defined_typ_params : Name.t option list)
+    (constructors_return_typ_params : Constructors.Single.t list)
+    : Name.t =
+    match name with
+      | FunctionParameter -> name
+      | Make s ->
+        let constructors_return_typ_params =
+          constructors_return_typ_params |> List.map (fun constructor_return_typ_params ->
+              constructor_return_typ_params.Constructors.Single.return_typ_params
+            ) in
+        match TypeIsGadt.check_if_not_gadt defined_typ_params constructors_return_typ_params with
+        | Some _ -> name
+        | None -> Make ("pre_" ^ s)
+
 let of_ocaml (typs : type_declaration list) : t Monad.t =
   match typs with
   | [ { typ_id; typ_type = { type_manifest = Some typ; type_params; _ }; _ } ] ->
@@ -709,6 +724,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (single_constructors, new_constructor_records) = List.split cases in
         let new_constructor_records =
           new_constructor_records |> Util.List.filter_map (fun x -> x) in
+        let name = gadt_prename name typ_args single_constructors in
         let constructor_records =
           match new_constructor_records with
           | [] -> constructor_records

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -583,22 +583,6 @@ let filter_in_free_vars
         None
   )
 
-let gadt_prename
-    (name : Name.t)
-    (defined_typ_params : Name.t option list)
-    (constructors_return_typ_params : Constructors.Single.t list)
-    : Name.t =
-    match name with
-      | FunctionParameter -> name
-      | Make s ->
-        let constructors_return_typ_params =
-          constructors_return_typ_params |> List.map (fun constructor_return_typ_params ->
-              constructor_return_typ_params.Constructors.Single.return_typ_params
-            ) in
-        match TypeIsGadt.check_if_not_gadt defined_typ_params constructors_return_typ_params with
-        | Some _ -> name
-        | None -> Make ("pre_" ^ s)
-
 let of_ocaml (typs : type_declaration list) : t Monad.t =
   match typs with
   | [ { typ_id; typ_type = { type_manifest = Some typ; type_params; _ }; _ } ] ->
@@ -724,7 +708,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (single_constructors, new_constructor_records) = List.split cases in
         let new_constructor_records =
           new_constructor_records |> Util.List.filter_map (fun x -> x) in
-        let name = gadt_prename name typ_args single_constructors in
         let constructor_records =
           match new_constructor_records with
           | [] -> constructor_records

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -96,17 +96,6 @@ let rec adt_parameters
     let typ_params = merge_typ_params defined_typ_params return_typ_params in
     adt_parameters typ_params constructors_return_typ_params
 
-
-let rec gadt_shape'
-    (defined_typ_params : InductiveVariable.t option list)
-    (constructors_return_typ_params : InductiveVariable.t option list list)
-  : InductiveVariable.t option list =
-  match constructors_return_typ_params with
-  | [] -> defined_typ_params
-  | return_typ_params :: constructors_return_typ_params ->
-    let typ_params = merge_typ_params defined_typ_params return_typ_params in
-    gadt_shape' typ_params constructors_return_typ_params
-
 let gadt_shape
     (defined_typ_params : InductiveVariable.t list)
     (constructors_return_typ_params : InductiveVariable.t list list)
@@ -116,7 +105,7 @@ let gadt_shape
     List.map (function xs ->
         List.map (function x -> Some x) xs)
       constructors_return_typ_params in
-  gadt_shape' defined_typ_params constructors_return_typ_params
+  List.fold_left merge_typ_params defined_typ_params constructors_return_typ_params
 
 (** Check if the type is not a GADT. If this is not a GADT, also return a
   prefered list of parameter names for the type variables. It merges the

--- a/src/typeIsGadt.ml
+++ b/src/typeIsGadt.ml
@@ -12,6 +12,10 @@ module IndParams = struct
   type t = InductiveVariable.t list
 end
 
+let get_name : InductiveVariable.t -> Name.t option = function
+  | InductiveVariable.Parameter name | Index name -> Some name
+  | _ -> None
+
 let get_parameters (typs : IndParams.t) : Name.t list =
   typs |> List.filter_map (function
       | InductiveVariable.Parameter name -> Some name


### PR DESCRIPTION

Closes #129

With this pull request I also start a big revamp of TypeIsGadt.ml to provide a much better interface. The key idea is to stop using `Name.t list option` in favor of `InductiveVariable.t list`, this way the datatypes constructors in `TypeDefinition` will have direct access to all the parameters and indexes, even if we are going to erase them later. Notice that in the future we will still need all this information stored somewhere in order to be able to fully translate Gadts.

It seems to me that `TypeIsGadt` should be a module to manage all the treatment of TypeVariables of inductives, with `Name.t list option` the clients of this module will still have to figure out how to treat this information.

Notice that `gadt_shape` is the same as `check_if_not_gadt`, but still using `InductiveVariable.t option list because` I didn't update how `Type.non_phantom_typs` works yet, and therefore it still relies on `option list`. In the future I will simplify `Typ.non_phantom_typs` to take full advantage of the new interface that I am building in `TypeIsGadt.ml`.