### PR TITLE
Avoid an infinite loop for recursive records

### DIFF
--- a/src/type.ml
+++ b/src/type.ml
@@ -103,6 +103,11 @@ let rec non_phantom_typs (path : Path.t) (typs : Types.type_expr list)
       return (Some (typ_params |> List.map (fun _ -> false)))
     else if is_tagged then
       return None
+    (* This is both an optimization and a way to avoid infinite loops on some
+       recursive types, such as recursive records (although we do not support
+       recursive records on the Coq side). *)
+    else if List.length typ_params = 0 then
+      return (Some [])
     else
       begin match typ_declaration.type_kind with
       | Type_abstract ->


### PR DESCRIPTION
A fix for https://github.com/clarus/coq-of-ocaml/issues/160 It seems that the issue is related to the computation of phantom-type variables on recursive records, which creates an infinite loop in `coq-of-ocaml`. In any case the recursive records are not handled in Coq as far as I know, but at least `coq-of-ocaml` does not fail.