### PR TITLE
Mutually Recursive GADTs Recognizes Tags Naively 

### DIFF
--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -113,11 +113,11 @@ type t = item list
 
 let of_ocaml_case
     (typ_name : Name.t)
-    (defined_typ_params : AdtParameters.t)
     (attributes : Attribute.t list)
+    (defined_typ_params : AdtParameters.t)
     (case : Types.constructor_declaration)
   : (item * (RecordSkeleton.t * Name.t list * Type.t) option) Monad.t =
-  let { Types.cd_args; cd_id; cd_loc; cd_res; _ } = case in
+  let { Types.cd_args; cd_id; cd_loc; cd_res; cd_attributes } = case in
   set_loc cd_loc (
     let* constructor_name =
       PathName.map_constructor_name

--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -116,7 +116,7 @@ let of_ocaml_case
     (attributes : Attribute.t list)
     (defined_typ_params : AdtParameters.t)
     (case : Types.constructor_declaration)
-  : (item * (RecordSkeleton.t * Name.t list * Type.t) option) Monad.t =
+  : (item * (RecordSkeleton.t * VarEnv.t * Type.t) option) Monad.t =
   let { Types.cd_args; cd_id; cd_loc; cd_res; cd_attributes } = case in
   set_loc cd_loc (
     let* constructor_name =
@@ -151,7 +151,8 @@ let of_ocaml_case
               )
               []
               (List.map Type.typ_args_of_typ record_params) in
-          let typ_args' = typ_args |> List.map (fun name ->
+          let new_typ_vars = VarEnv.reorg typ_args new_typ_vars in
+          let typ_args = new_typ_vars |> List.map (fun (name, _) ->
               Type.Variable name
             ) in
           return (
@@ -161,7 +162,7 @@ let of_ocaml_case
                   path = [typ_name];
                   base = constructor_name;
                 },
-                List.combine typ_args' (Type.tag_no_args typ_args')
+                List.combine typ_args (Type.tag_no_args typ_args)
               )
             ],
             new_typ_vars,
@@ -171,7 +172,7 @@ let of_ocaml_case
                 module_name = constructor_name;
                 typ_name = Name.suffix_by_skeleton constructor_name;
               },
-              typ_args,
+              new_typ_vars,
               Type.Apply (
                 MixedPath.PathName {
                   path = [typ_name];

--- a/src/pathName.ml
+++ b/src/pathName.ml
@@ -334,6 +334,7 @@ let is_tagged_variant
   | { type_kind = Type_variant _; type_attributes } ->
     let* type_attributes = Attribute.of_attributes type_attributes in
     return @@ Attribute.has_tag_gadt type_attributes
+  | { type_kind = Type_record _; _ } -> return true
   | _ | exception _ -> return false
 
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -1100,9 +1100,9 @@ let typ_vars_to_coq
   let typ_vars = VarEnv.group_by_kind typ_vars in
   if List.length typ_vars = 0
   then empty
-  else sep_before ^^
+  else nest (sep_before ^^
        (separate space
           (typ_vars |> List.map (fun (typ, vars) ->
-               delim ((separate space (vars |> List.rev |> List.map Name.to_coq))
-                      ^^ !^ ":" ^^ (Kind.to_coq typ)))
-       )) ^-^ sep_after
+               ((delim ((separate space (vars |> List.rev |> List.map Name.to_coq))
+                      ^^ !^ ":" ^^ (Kind.to_coq typ)))))
+          )) ^-^ sep_after)

--- a/src/type.ml
+++ b/src/type.ml
@@ -557,7 +557,7 @@ let rec of_typ_expr
     ) in
     of_typ_expr ~should_tag:should_tag with_free_vars typ_vars typ >>= fun (typ, typ_vars, new_typ_vars_typ) ->
     let non_phantom_vars = Name.Set.elements non_phantom_vars in
-    let new_typ_vars_typ = VarEnv.remove_many non_phantom_vars new_typ_vars_typ in
+    let new_typ_vars_typ = VarEnv.keep_only non_phantom_vars new_typ_vars_typ in
     return (ForallTyps (typ_args, typ), typ_vars, new_typ_vars_typ)
   | Tpackage (path, idents, typs) ->
       let* path_name = PathName.of_path_without_convert false path in
@@ -615,8 +615,8 @@ and of_typs_exprs
     (typ_vars : Name.t Name.Map.t)
   : (t list * Name.t Name.Map.t * VarEnv.t) Monad.t =
   if List.length tag_list <> List.length typs
-  then raise ([], typ_vars, []) Error.Category.Unexpected "Calling of_typs_exprs_constr with tag_list of different size of typs (they should have the same size)"
-  else    let tag_typs = List.combine typs tag_list in
+  then raise ([], typ_vars, []) Error.Category.Unexpected ("of_typs_exprs_constr: tag_list has size " ^ string_of_int (List.length tag_list) ^ ", while typs has size " ^ string_of_int (List.length typs) ^ ". They should have the same size")
+  else let tag_typs = List.combine typs tag_list in
     (Monad.List.fold_left
        (fun (typs, typ_vars, new_typ_vars) (typ, should_tag) ->
           of_typ_expr ~should_tag:should_tag with_free_vars typ_vars typ >>= fun (typ, typ_vars, new_typ_vars') ->
@@ -641,10 +641,10 @@ and get_constr_arg_tags
     else return @@ tag_no_args params
   | { type_kind = Type_record (decls, repr); type_params = params; _} ->
     (* Get the variables from param. Keep ordering *)
-    let* (params, _, typ_vars) = of_typs_exprs true params Name.Map.empty in
+    let* (_, _, typ_vars) = of_typs_exprs true params Name.Map.empty in
     let typ_vars = List.map (fun (ty, _) -> ty) typ_vars in
     let decls =  List.map (fun decl -> decl.ld_type) decls in
-    let* (typ, _, new_typ_vars) = of_typs_exprs true decls Name.Map.empty in
+    let* (_, _, new_typ_vars) = of_typs_exprs true decls Name.Map.empty in
     let new_typ_vars = VarEnv.reorg typ_vars new_typ_vars in
     return @@ List.map (fun (_, kind) ->
         match kind with
@@ -660,7 +660,7 @@ and get_constr_arg_tags
         | Kind.Tag -> true
         | _ -> false
       ) new_typ_vars
-  | _ | exception _ -> return []
+  | _ | exception _ -> print_string "exception!! \n\n"; return []
 
 and tag_typ_constr
     (path : Path.t)

--- a/src/type.ml
+++ b/src/type.ml
@@ -660,7 +660,7 @@ and get_constr_arg_tags
         | Kind.Tag -> true
         | _ -> false
       ) new_typ_vars
-  | _ | exception _ -> print_string "exception!! \n\n"; return []
+  | _ | exception _ -> return []
 
 and tag_typ_constr
     (path : Path.t)

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -154,10 +154,9 @@ module Inductive = struct
       notation ^^ !^ ":=" ^^ parens (
         (match typ_args with
          | [] -> empty
-         | _ :: _ ->
-             Type.typ_vars_to_coq parens (!^ "fun") (!^" => ") typ_args
-           ^-^ Type.to_coq (Some subst) None typ
+         | _ :: _ -> Type.typ_vars_to_coq parens (!^ "fun") (!^" => ") typ_args
         )
+        ^-^ Type.to_coq (Some subst) None typ
       )
     )
 
@@ -444,6 +443,9 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (fields_names, fields_types, new_typ_args) = Util.List.split3 fields in
         let new_typ_args = VarEnv.merge new_typ_args in
         let typ_args = VarEnv.reorg typ_args new_typ_args in
+        print_string (Name.to_string name ^"\n");
+        print_string ("size of fields types " ^ string_of_int (List.length fields_types) ^ "\n");
+        print_string ("size of typ_args " ^ string_of_int (List.length typ_args) ^ "\n");
         return (
           constructor_records,
           (

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -443,9 +443,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (fields_names, fields_types, new_typ_args) = Util.List.split3 fields in
         let new_typ_args = VarEnv.merge new_typ_args in
         let typ_args = VarEnv.reorg typ_args new_typ_args in
-        print_string (Name.to_string name ^"\n");
-        print_string ("size of fields types " ^ string_of_int (List.length fields_types) ^ "\n");
-        print_string ("size of typ_args " ^ string_of_int (List.length typ_args) ^ "\n");
         return (
           constructor_records,
           (


### PR DESCRIPTION
Fix #144 for rebasing

Also implemented records to recognize parameters that tags.

Example:

```
type 'a term =
  | T_Int : int -> int term
  | T_String : string -> string term
  | T_Sum : int term * int term -> int term
  | T_Pair : 'a term * 'b term -> ('a * 'b) term
[@@coq_tag_gadt]

and ('a, 'b) foo =
  | T_f of int
  | T_f2 : int term -> (int, string) foo
  | T_f3 of ('a, 'b) record_with_tag
  | T_f4 of {a : 'a term; b : string}

and ('a, 'b) record_with_tag = {
  x : 'b;
  y: 'a term

}
```

Should translate properly to

```
Inductive term : vtag -> Set :=
| T_Int : int -> term int_tag
| T_String : string -> term string_tag
| T_Sum : term int_tag -> term int_tag -> term int_tag
| T_Pair : forall {a b : vtag}, term a -> term b -> term (tuple_tag a b)

with foo : Set :=
| T_f : int -> foo
| T_f2 : term int_tag -> foo
| T_f3 : forall {a : vtag} {b : Set}, 'record_with_tag a b -> foo
| T_f4 : forall {a : vtag}, 'foo.T_f4 a -> foo

where "'record_with_tag" :=
  (fun (t_a : vtag) (t_b : Set) => record_with_tag_skeleton t_b (term t_a))
and "'foo.T_f4" := (fun (t_a : vtag) => foo.T_f4_skeleton (term t_a) string).
```

(Plus some skeleton boilerplate)