### PR TITLE
Implicit args

### DIFF
--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -204,10 +204,7 @@ let of_ocaml_case
         return ((List.map (fun v -> Type.Variable v) typ_args), List.rev new_typ_vars)
     in
     let typ_vars = VarEnv.union typ_vars new_typ_vars in
-    let* param_typs = if is_tagged
-      then Monad.List.map (Type.decode_var_tags typ_vars false) param_typs
-      else return param_typs
-    in
+    let* param_typs = Monad.List.map (Type.decode_var_tags typ_vars false) param_typs in
     let* tagged_return = Monad.List.map (Type.decode_var_tags typ_vars true) tagged_return in
     let* untagged_return =
       AdtParameters.get_return_typ_params defined_typ_params cd_res in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -952,8 +952,12 @@ and of_let
       | Texp_function _ -> false
       | _ -> true
       end ->
-      Type.of_typ_expr true typ_vars exp_type >>= fun (_, _, new_typ_vars) ->
-      return (List.length new_typ_vars <> 0)
+      Type.of_typ_expr true typ_vars exp_type >>= fun (_, typ_vars', _) ->
+      let typ_vars = List.map fst (Name.Map.bindings typ_vars) in
+      let new_vars = List.fold_left (fun map var ->
+          Name.Map.remove var map
+        ) typ_vars' typ_vars in
+      return (not @@ Name.Map.is_empty new_vars)
     | _ -> return true
     end >>= fun is_function ->
     begin match cases with

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -718,7 +718,7 @@ and of_match :
       let* motive = Type.decode_var_tags new_typ_vars false motive in
       let (cast, args) = Type.normalize_constructor cast in
       (* Only generates dependent pattern matching for actual gadts *)
-      if List.length args = 0 || (Type.is_native_type cast)
+      if List.length args = 0 || Type.is_native_type cast
       then return None
       else return (Some ({cast; args; motive}))
     end
@@ -887,7 +887,10 @@ and import_let_fun
     | _ ->
       raise None Unexpected "A variable name instead of a pattern was expected"
     ) >>= fun x ->
+    let predefined_variables = List.map snd (Name.Map.bindings typ_vars) in
     Type.of_typ_expr true typ_vars vb_expr.exp_type >>= fun (e_typ, typ_vars, new_typ_vars) ->
+    let* e_typ = Type.decode_var_tags new_typ_vars false e_typ in
+    let new_typ_vars = VarEnv.remove_many predefined_variables new_typ_vars in
     match x with
     | None -> return None
     | Some x ->

--- a/src/type.ml
+++ b/src/type.ml
@@ -436,7 +436,7 @@ let rec of_typ_expr
     let (typ_vars, new_typ_vars, name) =
       if Name.Map.mem source_name typ_vars then (
         let name = Name.Map.find source_name typ_vars in
-        (typ_vars, [], name)
+        (typ_vars, [(name, typ)], name)
       ) else (
         let typ_vars = Name.Map.add source_name generated_name typ_vars in
         (typ_vars, [(generated_name, typ)], generated_name)
@@ -459,9 +459,7 @@ let rec of_typ_expr
     let is_pident = match path with
       | Path.Pident _ -> true
       | _ -> false in
-
     let* is_tagged_variant = PathName.is_tagged_variant path in
-
     if not is_tagged_variant
     then begin
       let tag_list = tag_no_args typs in

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -416,6 +416,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
             "Polymorphic variant types are defined as standard algebraic types"
         | _ ->
           Type.of_typ_expr true Name.Map.empty typ >>= fun (typ, _, typ_args) ->
+          let* typ = Type.decode_var_tags typ_args false typ in
           return (
             constructor_records,
             (
@@ -443,6 +444,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (fields_names, fields_types, new_typ_args) = Util.List.split3 fields in
         let new_typ_args = VarEnv.merge new_typ_args in
         let typ_args = VarEnv.reorg typ_args new_typ_args in
+        let* fields_types = Monad.List.map (Type.decode_var_tags typ_args false) fields_types in
         return (
           constructor_records,
           (


### PR DESCRIPTION
This pull request changes the behavior of how `new_typ_vars` in `Type.of_typ_expr` works. 

In the past it would only a new variable in the environment if it was never seen before, keeping track of the old variables through `typ_vars`. But this behavior is incompatible with how the tags algorithm works in the sense that it has to keep track of all the old variables seen in `new_typ_vars`, otherwise the tag detection will fail during `VarEnv.merge`. 

The only place where this change affects is during function translation, the code have been updated accordingly. 