### PR TITLE
Change computation of new_typ_vars in Type.of_typ_expr & Small fixes on how tags interacts within records

### DIFF
--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -204,10 +204,7 @@ let of_ocaml_case
         return ((List.map (fun v -> Type.Variable v) typ_args), List.rev new_typ_vars)
     in
     let typ_vars = VarEnv.union typ_vars new_typ_vars in
-    let* param_typs = if is_tagged
-      then Monad.List.map (Type.decode_var_tags typ_vars false) param_typs
-      else return param_typs
-    in
+    let* param_typs = Monad.List.map (Type.decode_var_tags typ_vars false) param_typs in
     let* tagged_return = Monad.List.map (Type.decode_var_tags typ_vars true) tagged_return in
     let* untagged_return =
       AdtParameters.get_return_typ_params defined_typ_params cd_res in

--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -152,6 +152,11 @@ let of_ocaml_case
               []
               (List.map Type.typ_args_of_typ record_params) in
           let new_typ_vars = VarEnv.reorg typ_args new_typ_vars in
+          let tag_typs = List.map (fun (_, kind) ->
+              match kind with
+              | Kind.Tag -> true
+              | _ -> false
+            ) new_typ_vars in
           let typ_args = new_typ_vars |> List.map (fun (name, _) ->
               Type.Variable name
             ) in
@@ -162,7 +167,7 @@ let of_ocaml_case
                   path = [typ_name];
                   base = constructor_name;
                 },
-                List.combine typ_args (Type.tag_no_args typ_args)
+                List.combine typ_args tag_typs
               )
             ],
             new_typ_vars,

--- a/src/adtConstructors.ml
+++ b/src/adtConstructors.ml
@@ -19,15 +19,6 @@ module RecordSkeleton = struct
       !^ "Module" ^^ Name.to_coq module_name ^-^ !^ "." ^^ newline ^^
       indent (
         !^ "Record" ^^ !^ "record" ^^
-        (* begin match typ_args with *)
-          (* | [] -> empty *)
-          (* | _ :: _ -> *)
-            (* Type. *)
-            (* braces (nest (
-             *     separate space (List.map Name.to_coq typ_args) ^^
-             *     !^ ":" ^^ Pp.set
-             *   )) *)
-        (* end *)
         Type.typ_vars_to_coq braces space space typ_args
         ^^
         nest (!^ ":" ^^ Pp.set) ^^

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -952,8 +952,12 @@ and of_let
       | Texp_function _ -> false
       | _ -> true
       end ->
-      Type.of_typ_expr true typ_vars exp_type >>= fun (_, _, new_typ_vars) ->
-      return (List.length new_typ_vars <> 0)
+      Type.of_typ_expr true typ_vars exp_type >>= fun (_, typ_vars', _) ->
+      let typ_vars = List.map fst (Name.Map.bindings typ_vars) in
+      let new_vars = List.fold_left (fun map var ->
+          Name.Map.remove var map
+        ) typ_vars' typ_vars in
+      return (not @@ Name.Map.is_empty new_vars)
     | _ -> return true
     end >>= fun is_function ->
     begin match cases with

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -718,7 +718,7 @@ and of_match :
       let* motive = Type.decode_var_tags new_typ_vars false motive in
       let (cast, args) = Type.normalize_constructor cast in
       (* Only generates dependent pattern matching for actual gadts *)
-      if List.length args = 0 || (Type.is_native_type cast)
+      if List.length args = 0 || Type.is_native_type cast
       then return None
       else return (Some ({cast; args; motive}))
     end
@@ -887,7 +887,10 @@ and import_let_fun
     | _ ->
       raise None Unexpected "A variable name instead of a pattern was expected"
     ) >>= fun x ->
+    let predefined_variables = List.map snd (Name.Map.bindings typ_vars) in
     Type.of_typ_expr true typ_vars vb_expr.exp_type >>= fun (e_typ, typ_vars, new_typ_vars) ->
+    let* e_typ = Type.decode_var_tags new_typ_vars false e_typ in
+    let new_typ_vars = VarEnv.remove_many predefined_variables new_typ_vars in
     match x with
     | None -> return None
     | Some x ->

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -887,6 +887,8 @@ and import_let_fun
     | _ ->
       raise None Unexpected "A variable name instead of a pattern was expected"
     ) >>= fun x ->
+    (* Don't forget to save the implicit variables that are already in scope
+     * and remove them later  *)
     let predefined_variables = List.map snd (Name.Map.bindings typ_vars) in
     Type.of_typ_expr true typ_vars vb_expr.exp_type >>= fun (e_typ, typ_vars, new_typ_vars) ->
     let* e_typ = Type.decode_var_tags new_typ_vars false e_typ in
@@ -952,6 +954,10 @@ and of_let
       | Texp_function _ -> false
       | _ -> true
       end ->
+      (* Figure out if the let expression being translated is a function by
+       * checking if it introduced any new variables to typ_vars
+       * Is there a better way to do this?
+       * *)
       Type.of_typ_expr true typ_vars exp_type >>= fun (_, typ_vars', _) ->
       let typ_vars = List.map fst (Name.Map.bindings typ_vars) in
       let new_vars = List.fold_left (fun map var ->

--- a/src/signatureAxioms.ml
+++ b/src/signatureAxioms.ml
@@ -126,6 +126,7 @@ let rec of_signature (signature : Typedtree.signature) : t Monad.t =
           AdtParameters.of_ocaml
         ) >>= fun typ_params ->
         let typ_params = AdtParameters.get_parameters typ_params in
+        let typ_params = typ_params |> List.map (fun field -> (field, Kind.Set)) in
         let* name = Name.of_ident false ci_id_class_type in
         begin match ci_expr with
         | {

--- a/src/type.ml
+++ b/src/type.ml
@@ -436,7 +436,7 @@ let rec of_typ_expr
     let (typ_vars, new_typ_vars, name) =
       if Name.Map.mem source_name typ_vars then (
         let name = Name.Map.find source_name typ_vars in
-        (typ_vars, [], name)
+        (typ_vars, [(name, typ)], name)
       ) else (
         let typ_vars = Name.Map.add source_name generated_name typ_vars in
         (typ_vars, [(generated_name, typ)], generated_name)
@@ -459,9 +459,7 @@ let rec of_typ_expr
     let is_pident = match path with
       | Path.Pident _ -> true
       | _ -> false in
-
     let* is_tagged_variant = PathName.is_tagged_variant path in
-
     if not is_tagged_variant
     then begin
       let tag_list = tag_no_args typs in

--- a/src/type.ml
+++ b/src/type.ml
@@ -696,11 +696,11 @@ let rec decode_var_tags_aux
         | Some _ -> return typ
     end
   | Arrow (t1, t2) ->
-    let* t1 = decode_var_tags_aux typ_vars in_native true t1 in
-    let* t2 = decode_var_tags_aux typ_vars in_native true t2 in
+    let* t1 = decode_var_tags_aux typ_vars in_native is_tag t1 in
+    let* t2 = decode_var_tags_aux typ_vars in_native is_tag t2 in
     return @@ Arrow (t1, t2)
   | Tuple ts ->
-    let* ts = Monad.List.map (decode_var_tags_aux typ_vars in_native true) ts in
+    let* ts = Monad.List.map (decode_var_tags_aux typ_vars in_native is_tag) ts in
     return @@ Tuple ts
   | Apply (mpath, ts) ->
     let (ts, bs) = List.split ts in

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -417,6 +417,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
             "Polymorphic variant types are defined as standard algebraic types"
         | _ ->
           Type.of_typ_expr true Name.Map.empty typ >>= fun (typ, _, typ_args) ->
+          let* typ = Type.decode_var_tags typ_args false typ in
           return (
             constructor_records,
             (
@@ -444,6 +445,7 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
         let (fields_names, fields_types, new_typ_args) = Util.List.split3 fields in
         let new_typ_args = VarEnv.merge new_typ_args in
         let typ_args = VarEnv.reorg typ_args new_typ_args in
+        let* fields_types = Monad.List.map (Type.decode_var_tags typ_args false) fields_types in
         return (
           constructor_records,
           (

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -382,7 +382,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
     return (Abstract (name, typ_args_with_unknowns))
   | [ { typ_id; typ_type = { type_kind = Type_record (fields, _); type_params; _ }; _ } ] ->
     let* name = Name.of_ident false typ_id in
-    AdtParameters.of_ocaml type_params >>= fun typ_args ->
     (fields |> Monad.List.map (fun { Types.ld_id = x; ld_type = typ; _ } ->
       let* x = Name.of_ident false x in
       Type.of_typ_expr true Name.Map.empty typ >>= fun (typ, _, new_typ_args) ->

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -388,7 +388,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
       Type.of_typ_expr true Name.Map.empty typ >>= fun (typ, _, new_typ_args) ->
       return (x, typ, new_typ_args)
     )) >>= fun fields ->
-
     let* (_, _, typ_args) = Type.of_typs_exprs true type_params Name.Map.empty in
     let typ_args = List.map fst typ_args in
     let (fields_names, fields_types, new_typ_args) = Util.List.split3 fields in
@@ -396,11 +395,6 @@ let of_ocaml (typs : type_declaration list) : t Monad.t =
     let typ_args = VarEnv.reorg typ_args new_typ_args in
     let* fields_types = Monad.List.map (Type.decode_var_tags typ_args false) fields_types in
     let fields = List.combine fields_names fields_types in
-
-    (* let free_vars = Type.typ_args_of_typs (List.map snd fields) in
-     * let typ_args = AdtParameters.get_parameters typ_args in
-     * let typ_args = filter_in_free_vars typ_args free_vars in *)
-
     return (Record (name, typ_args, fields, true))
   | [ { typ_id; typ_type = { type_kind = Type_open; _ }; _ } ] ->
     let* name = Name.of_ident false typ_id in

--- a/tests/gadts.ml
+++ b/tests/gadts.ml
@@ -20,7 +20,7 @@ type 'a term =
   | T_Int : int -> int term
   | T_String : string -> string term
   | T_Sum : int term * int term -> int term
-  | T_Pair : 'a term * 'b term -> ('a * 'b) term
+  (* | T_Pair : 'a term * 'b term -> ('a * 'b) term *)
 [@@coq_tag_gadt]
 
 let rec get_int (e : int term) : int =
@@ -28,6 +28,11 @@ let rec get_int (e : int term) : int =
   | T_Int n -> n
   | T_Sum (e1, e2) -> get_int e1 + get_int e2
   | _ -> .
+
+let rec interp : type a. a term -> a = function
+  | T_Int n -> n
+  | T_String s -> s
+  | T_Sum (s1, s2) -> interp s1 + interp s2
 
 
 type 'a one_case =

--- a/tests/gadts.v
+++ b/tests/gadts.v
@@ -26,8 +26,7 @@ Fixpoint proj_int (e : expr) : int :=
 Inductive term : vtag -> Set :=
 | T_Int : int -> term int_tag
 | T_String : string -> term string_tag
-| T_Sum : term int_tag -> term int_tag -> term int_tag
-| T_Pair : forall {a b : vtag}, term a -> term b -> term (tuple_tag a b).
+| T_Sum : term int_tag -> term int_tag -> term int_tag.
 
 Fixpoint get_int (e : term int_tag) : int :=
   match e in term t0 return t0 = int_tag -> int with
@@ -36,6 +35,13 @@ Fixpoint get_int (e : term int_tag) : int :=
     fun eq0 => ltac:(subst; exact (Z.add (get_int e1) (get_int e2)))
   | _ => ltac:(discriminate)
   end eq_refl.
+
+Fixpoint interp {a : vtag} (function_parameter : term a) : decode_vtag a :=
+  match function_parameter with
+  | T_Int n => n
+  | T_String s => s
+  | T_Sum s1 s2 => Z.add (interp s1) (interp s2)
+  end.
 
 Inductive one_case : Set :=
 | SingleCase : one_case


### PR DESCRIPTION
This pull request changes the behavior of how new_typ_vars in Type.of_typ_expr works.

In the past it would only a new variable in the environment if it was never seen before, keeping track of the old variables through typ_vars. But this behavior is incompatible with how the tags algorithm works in the sense that it has to keep track of all the old variables seen in new_typ_vars, otherwise the tag detection will fail during VarEnv.merge.

The only place where this change affects is during function translation, the code have been updated accordingly.

It also finishes implementing how tags properly interacts with records.